### PR TITLE
#7: Add command to atuomatically attach inspector to running WireMock server

### DIFF
--- a/src/WireMockInspector/App.axaml.cs
+++ b/src/WireMockInspector/App.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using System.CommandLine;
+using System.Diagnostics;
 using WireMockInspector.ViewModels;
 using WireMockInspector.Views;
 
@@ -17,13 +19,49 @@ namespace WireMockInspector
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                desktop.MainWindow = new MainWindow
+                var mainWindowViewModel = new MainWindowViewModel();
+                var mainWindow = new MainWindow
                 {
-                    DataContext = new MainWindowViewModel(),
+                    DataContext = mainWindowViewModel,
                 };
+               
+                if (desktop.Args is { } args)
+                {
+                    var rootCommand = new RootCommand("WireMockInspector CLI");
+
+                    var attachCommand = new Command("attach", "Attach WireMockInspector to running WireMock server");
+                    var adminUrlOption = new Option<string>("--adminUrl") { IsRequired = true };
+                    attachCommand.AddOption(adminUrlOption);
+                    var autoLoadOption = new Option<bool>("--autoLoad") { IsRequired = false };
+                    attachCommand.AddOption(autoLoadOption);
+                    var instanceNameOption = new Option<string>("--instanceName") { IsRequired = false };
+                    attachCommand.AddOption(instanceNameOption);
+
+                    attachCommand.SetHandler((adminUrl, autoLoad, instanceName) =>
+                    {
+                        mainWindow.Settings = new StartupSettings
+                        {
+                            AdminUrl = adminUrl,
+                            InstanceName = instanceName,
+                            AutoLoad = autoLoad
+                        };
+                    }, adminUrlOption, autoLoadOption, instanceNameOption);
+                    rootCommand.AddCommand(attachCommand);
+                    rootCommand.SetHandler(() => { });
+                    rootCommand.Invoke(args);
+                }
+
+                desktop.MainWindow = mainWindow;
             }
 
             base.OnFrameworkInitializationCompleted();
         }
+    }
+
+    public class StartupSettings
+    {
+        public string AdminUrl { get; set; }
+        public bool AutoLoad { get; set; }
+        public string InstanceName { get; set; }
     }
 }

--- a/src/WireMockInspector/ViewModels/MainWindowViewModel.cs
+++ b/src/WireMockInspector/ViewModels/MainWindowViewModel.cs
@@ -90,7 +90,7 @@ namespace WireMockInspector.ViewModels
                 var requestsTask = api.GetRequestsAsync();
                 var mappingsTask = api.GetMappingsAsync();
                 await Task.WhenAll(requestsTask, mappingsTask).ConfigureAwait(false);
-                return (requests: requestsTask.Result,mappings: mappingsTask.Result);
+                return (requests: requestsTask.Result, mappings: mappingsTask.Result);
             }); 
 
             LoadRequestsCommand
@@ -153,7 +153,10 @@ namespace WireMockInspector.ViewModels
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(settings =>
                 {
-                    AdminUrl = settings.AdminUrl;
+                    if (string.IsNullOrWhiteSpace(AdminUrl))
+                    {
+                        AdminUrl = settings.AdminUrl;
+                    }
                 });
 
             this.WhenAnyValue(x => x.SelectedRequest)

--- a/src/WireMockInspector/Views/MainWindow.axaml
+++ b/src/WireMockInspector/Views/MainWindow.axaml
@@ -45,7 +45,7 @@
         <StackPanel>
             <views1:NewVersionInfo DataContext="{Binding NewVersion}" IsVisible="{Binding IsVisible}"></views1:NewVersionInfo>
             <Grid ColumnDefinitions="*, Auto" >
-                <TextBox MinWidth="1" Text="{Binding AdminUrl}" Watermark="Admin API URL"></TextBox>
+                <TextBox MinWidth="1" Text="{Binding AdminUrl, Mode=TwoWay}" Watermark="Admin API URL"></TextBox>
                 <Button Grid.Column="1" Command="{Binding LoadRequestsCommand}" Margin="10,0,0,0"  ToolTip.Tip="Load requests">
                     <PathIcon Data="{StaticResource arrow_sync_circle_regular}" HorizontalAlignment="Center" VerticalAlignment="Center" ></PathIcon>
                 </Button>

--- a/src/WireMockInspector/Views/MainWindow.axaml.cs
+++ b/src/WireMockInspector/Views/MainWindow.axaml.cs
@@ -5,15 +5,25 @@ using MessageBox.Avalonia.Enums;
 using ReactiveUI;
 using WireMockInspector.ViewModels;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
 using Avalonia.Controls;
+using WireMock.Admin.Mappings;
+using WireMock.Admin.Requests;
 
 
 namespace WireMockInspector.Views
 {
     public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
     {
+        private string? _mainTitle;
+
+        public StartupSettings? Settings { get; set; }
+
         public MainWindow()
         {
+            
             InitializeComponent();
             this.WhenActivated((disposables) =>
             {
@@ -27,8 +37,26 @@ namespace WireMockInspector.Views
                             MessageBox.Avalonia.Enums.Icon.Error, WindowStartupLocation.CenterOwner);
                         msg.ShowDialog(this);
                     }).DisposeWith(disposables);
-            });
 
+
+                if (Settings != null)
+                {
+                    ViewModel.AdminUrl = Settings.AdminUrl;
+                    if (Settings.AutoLoad)
+                    {
+                      ViewModel.LoadRequestsCommand.Execute().Subscribe().DisposeWith(disposables);
+                    }
+
+                    if (string.IsNullOrWhiteSpace(Settings.InstanceName) == false)
+                    {
+                        SetInstanceName(Settings.InstanceName);
+                    }
+                }
+            });
+            _mainTitle = $"WireMockInspector v{Assembly.GetEntryAssembly()!.GetName().Version}";
+            Title = _mainTitle;
         }
+
+        public void SetInstanceName(string instanceName) => Title = $"{_mainTitle} - {instanceName}";
     }
 }

--- a/src/WireMockInspector/WireMockInspector.csproj
+++ b/src/WireMockInspector/WireMockInspector.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview5" />
     <PackageReference Include="Markdown.Avalonia" Version="11.0.0-a9" />
     <PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev5" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="WireMock.Net.RestClient" Version="1.5.22" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
   </ItemGroup>


### PR DESCRIPTION
Example usage 

```shell
wiremockinspector attach --adminUrl http://localhost:1088 --autoLoad --instanceName Test
```