### PR TITLE
open update instructions link

### DIFF
--- a/src/WireMockInspector/ViewModels/GithubUpdater.cs
+++ b/src/WireMockInspector/ViewModels/GithubUpdater.cs
@@ -84,6 +84,11 @@ public class NewVersionInfoViewModel:ViewModelBase
         OpenWebsite(@$"https://github.com/{_repositorySku}/releases/");
     }
 
+    public void OpenUpdateInstructions()
+    {
+        OpenWebsite(@$"https://github.com/{_repositorySku}/#how-to-update");
+    }
+
     private static void OpenWebsite(string url)
     {
         Process.Start(new ProcessStartInfo

--- a/src/WireMockInspector/Views/NewVersionInfo.axaml
+++ b/src/WireMockInspector/Views/NewVersionInfo.axaml
@@ -11,7 +11,8 @@
         <Border BorderBrush="#FF0000" BorderThickness="1"  >
             <StackPanel  Orientation="Horizontal" Margin="20" VerticalAlignment="Center">
                 <TextBlock VerticalAlignment="Center" Text="{Binding Version, StringFormat='{} A newer version {0} is available'}"></TextBlock>
-                <Button Margin="20,0,0,0" VerticalAlignment="Center" Command="{Binding  OpenReleaseLog}">Check release log</Button>
+                <Button Margin="20,0,0,0" VerticalAlignment="Center" Command="{Binding OpenReleaseLog}">Check release log</Button>
+                <Button Margin="20,0,0,0" VerticalAlignment="Center" Command="{Binding OpenUpdateInstructions}">How to update</Button>
                 <Button Margin="20,0,0,0" VerticalAlignment="Center" Command="{Binding DismissNewVersion}">Dismiss</Button>
             </StackPanel>
         </Border>


### PR DESCRIPTION
Hello 👋 

Love the new banner with notification about new release available.
![image](https://github.com/WireMock-Net/WireMockInspector/assets/2392583/6dcd94a5-06b4-45b5-8849-dc4ffe5ed0b9)

I'm just too lazy to search for update instructions, and never remember how to do it from top on my head, so would love to have button navigating to readme.