### PR TITLE
New version info visibility

### DIFF
--- a/src/WireMockInspector/Views/NewVersionInfo.axaml
+++ b/src/WireMockInspector/Views/NewVersionInfo.axaml
@@ -7,7 +7,7 @@
              x:Class="WireMockInspector.Views.NewVersionInfo"
              x:DataType="viewModels:NewVersionInfoViewModel"
              >
-    <StackPanel Height="75"  IsVisible="{Binding IsVisible}" Margin="0,0,0,20">
+    <StackPanel Name="StackPanel" Height="75" IsVisible="{Binding IsVisible}" Margin="0,0,0,20">
         <Border BorderBrush="#FF0000" BorderThickness="1"  >
             <StackPanel  Orientation="Horizontal" Margin="20" VerticalAlignment="Center">
                 <TextBlock VerticalAlignment="Center" Text="{Binding Version, StringFormat='{} A newer version {0} is available'}"></TextBlock>

--- a/src/WireMockInspector/Views/NewVersionInfo.axaml.cs
+++ b/src/WireMockInspector/Views/NewVersionInfo.axaml.cs
@@ -7,6 +7,8 @@ namespace WireMockInspector.Views
         public NewVersionInfo()
         {
             InitializeComponent();
+            
+            this.StackPanel.IsVisible = false;
         }
     }
 }


### PR DESCRIPTION
By default new version information will show no matter if new version is actually available or not.
If find it a little bit annoying when running inspector multiple times a day, please ignore if it's not affecting you :)