### PR TITLE
Refactor SearchHelper.cs and update field types

### DIFF
--- a/src/WireMock.Net.Extensions.WireMockInspector/WireMock.Net.Extensions.WireMockInspector.csproj
+++ b/src/WireMock.Net.Extensions.WireMockInspector/WireMock.Net.Extensions.WireMockInspector.csproj
@@ -27,6 +27,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WireMock.Net.Abstractions" Version="1.5.24" />
+    <PackageReference Include="WireMock.Net.Abstractions" Version="1.5.60" />
   </ItemGroup>
 </Project>

--- a/src/WireMockInspector/CodeGenerators/CSharpFormatter.cs
+++ b/src/WireMockInspector/CodeGenerators/CSharpFormatter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-namespace WireMockInspector.ViewModels;
+namespace WireMockInspector.CodeGenerators;
 
 internal static class CSharpFormatter
 {

--- a/src/WireMockInspector/ViewModels/SearchHelper.cs
+++ b/src/WireMockInspector/ViewModels/SearchHelper.cs
@@ -30,13 +30,13 @@ public class SearchHelper
         foreach (var request in requests)
         {
             var doc = new Document
-        {
-            new StringField("_id", request.Raw.Guid.ToString(), Field.Store.YES),
-            new StringField("clientip", request.Raw.Request.ClientIP.ToLower(), Field.Store.NO),
-            new StringField("method", request.Method.ToLower(), Field.Store.NO),
-            new StringField("url", request.Raw.Request.Url.ToLower(), Field.Store.NO),
-            new StringField("path", request.Path.ToLower(), Field.Store.NO)
-        };
+            {
+                new StringField("_id", request.Raw.Guid.ToString(), Field.Store.YES),
+                new StringField("clientip", request.Raw.Request.ClientIP.ToLower(), Field.Store.NO),
+                new StringField("method", request.Method.ToLower(), Field.Store.NO),
+                new StringField("url", request.Raw.Request.Url.ToLower(), Field.Store.NO),
+                new StringField("path", request.Path.ToLower(), Field.Store.NO)
+            };
 
             if (request.Raw.Request.Headers is { } headers)
                 foreach (var (key, val) in headers)

--- a/src/WireMockInspector/ViewModels/SearchHelper.cs
+++ b/src/WireMockInspector/ViewModels/SearchHelper.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Analysis.Standard;
+﻿using System;
+using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
@@ -29,13 +30,13 @@ public class SearchHelper
         foreach (var request in requests)
         {
             var doc = new Document
-            {
-                new StringField("_id", request.Raw.Guid.ToString(), Field.Store.YES),
-                new StringField("clientip", request.Raw.Request.ClientIP.ToLower(), Field.Store.NO),
-                new StringField("method", request.Method.ToLower(), Field.Store.NO),
-                new StringField("url", request.Raw.Request.Url.ToLower(), Field.Store.NO),
-                new StringField("path", request.Path.ToLower(), Field.Store.NO)
-            };
+        {
+            new StringField("_id", request.Raw.Guid.ToString(), Field.Store.YES),
+            new StringField("clientip", request.Raw.Request.ClientIP.ToLower(), Field.Store.NO),
+            new StringField("method", request.Method.ToLower(), Field.Store.NO),
+            new StringField("url", request.Raw.Request.Url.ToLower(), Field.Store.NO),
+            new StringField("path", request.Path.ToLower(), Field.Store.NO)
+        };
 
             if (request.Raw.Request.Headers is { } headers)
                 foreach (var (key, val) in headers)
@@ -60,13 +61,13 @@ public class SearchHelper
                     doc.Add(new StringField("param", key.ToLower(), Field.Store.NO));
                     foreach (var v in val)
                     {
-                        doc.Add(new StringField( ToFieldName("param",key), v.ToLower(), Field.Store.NO));
+                        doc.Add(new StringField(ToFieldName("param", key), v.ToLower(), Field.Store.NO));
                     }
                 }
 
             if (request.Raw.Request.Body is { } requestBody)
             {
-                doc.Add(new StringField("request.body", requestBody.ToLower(), Field.Store.NO));
+                doc.Add(new TextField("request.body", requestBody.ToLower(), Field.Store.NO));
             }
 
             doc.Add(new StringField("status", request.Raw.Response.StatusCode?.ToString()?.ToLower() ?? "", Field.Store.NO));
@@ -83,11 +84,11 @@ public class SearchHelper
 
             if (request.Raw.Response.Body is { } responseBody)
             {
-                doc.Add(new StringField("response.body", responseBody.ToLower(), Field.Store.NO));
+                doc.Add(new TextField("response.body", responseBody.ToLower(), Field.Store.NO));
             }
             else if (request.Raw.Response.BodyAsJson is { } responseBodyAsJson)
             {
-                doc.Add(new StringField("response.body", responseBodyAsJson.ToString()?.ToLower() ?? string.Empty, Field.Store.NO));
+                doc.Add(new TextField("response.body", responseBodyAsJson.ToString()?.ToLower() ?? string.Empty, Field.Store.NO));
             }
 
             indexWriter.AddDocument(doc);

--- a/src/WireMockInspector/WireMockInspector.csproj
+++ b/src/WireMockInspector/WireMockInspector.csproj
@@ -40,18 +40,18 @@
   <ItemGroup>
     <PackageReference Include="AutomaticGraphLayout" Version="1.1.12" />
     <PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
-    <PackageReference Include="Avalonia" Version="11.0.6" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.5" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Svg" Version="11.0.0.9" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.6" />
+    <PackageReference Include="Avalonia" Version="11.0.11" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.11" />
+    <PackageReference Include="Avalonia.Svg" Version="11.0.0.18" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.11" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.6" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.6" />
-    <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.5" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.11" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.11" />
+    <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
     <PackageReference Include="DiffPlex" Version="1.7.2" />
-    <PackageReference Include="Fluid.Core" Version="2.5.0" />
+    <PackageReference Include="Fluid.Core" Version="2.10.0" />
     <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
@@ -60,8 +60,8 @@
     <PackageReference Include="Markdown.Avalonia.SyntaxHigh" Version="11.0.2" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.1.5.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.56" />
-    <PackageReference Include="WireMock.Net.RestClient" Version="1.5.46" />
+    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.58" />
+    <PackageReference Include="WireMock.Net.RestClient" Version="1.5.60" />
     <!--<PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />-->
   </ItemGroup>
 


### PR DESCRIPTION
Changed `StringField` to `TextField` for `request.body`, `response.body`, and `response.bodyAsJson` to handle large text data better.

To fix this crash
https://github.com/WireMock-Net/WireMockInspector/issues/33